### PR TITLE
docs: SNAPSHOT版バージョン管理ルールを追加

### DIFF
--- a/docs/workflow/DEVELOPMENT_WORKFLOW.md
+++ b/docs/workflow/DEVELOPMENT_WORKFLOW.md
@@ -480,7 +480,57 @@ MAJOR.MINOR.PATCH
   └────────────── 破壊的変更（後方互換なし）
 ```
 
-### 6.2 本プロジェクトのバージョン履歴
+### 6.2 開発中バージョン（SNAPSHOT）
+
+開発中のバージョンには `-SNAPSHOT` サフィックスを付与し、リリース済みバージョンと区別する。
+
+#### 6.2.1 バージョン命名規則
+
+| フェーズ | バージョン例 | 説明 |
+|---------|------------|------|
+| リリース済み | `0.0.17` | npm publishされた安定版 |
+| 開発中（develop） | `0.0.18-SNAPSHOT` | 次リリースに向けた開発版 |
+| 開発中（feature） | `0.0.18-SNAPSHOT.cli-npx` | 特定機能の開発版（並行開発時） |
+
+#### 6.2.2 運用フロー
+
+```
+main (0.0.17)                          ← リリース済み
+  │
+  └── develop (0.0.18-SNAPSHOT)        ← 次版開発中
+        │
+        ├── feature/cli-npx (0.0.18-SNAPSHOT.cli-npx)
+        │                              ↑ 並行開発時は機能名を付与
+        └── feature/csv (0.0.18-SNAPSHOT.csv)
+```
+
+1. **リリース後**: developのバージョンを `X.Y.Z-SNAPSHOT` に更新
+2. **feature開発時**:
+   - 単独開発: `X.Y.Z-SNAPSHOT` のまま
+   - 並行開発: `X.Y.Z-SNAPSHOT.機能名` に変更（任意）
+3. **developマージ時**: `X.Y.Z-SNAPSHOT` に統一
+4. **リリース時**: `-SNAPSHOT` を削除して `X.Y.Z` に
+
+#### 6.2.3 semver準拠
+
+`-SNAPSHOT` はsemverの有効なプレリリース識別子。バージョン比較:
+
+```
+0.0.17 < 0.0.18-SNAPSHOT < 0.0.18-SNAPSHOT.cli-npx < 0.0.18
+```
+
+#### 6.2.4 npm pack時の区別
+
+並行開発時、各featureのビルドを区別するために機能名サフィックスを使用:
+
+```bash
+# feature/cli-npx ブランチ
+npm version 0.0.18-SNAPSHOT.cli-npx --no-git-tag-version
+npm pack
+# → evmtools-node-0.0.18-SNAPSHOT.cli-npx.tgz
+```
+
+### 6.3 本プロジェクトのバージョン履歴
 
 | バージョン | 主な変更 |
 |-----------|---------|
@@ -526,23 +576,26 @@ MAJOR.MINOR.PATCH
 ### 8.1 Feature開発時
 
 - [ ] `develop`から`feature/*`ブランチを作成
+- [ ] （並行開発時）バージョンを `X.Y.Z-SNAPSHOT.機能名` に変更
 - [ ] 要件定義書を作成（Forward時）
 - [ ] 仕様書を作成
 - [ ] テストコードを作成
 - [ ] 実装
 - [ ] 全テストPASS確認
 - [ ] トレーサビリティ更新
+- [ ] （並行開発時）バージョンを `X.Y.Z-SNAPSHOT` に戻す
 - [ ] PRを作成
 - [ ] レビュー・マージ
 
 ### 8.2 リリース時
 
 - [ ] `develop`から`release/*`ブランチを作成
-- [ ] バージョン番号更新（package.json）
+- [ ] バージョン番号更新（`-SNAPSHOT` を削除）
 - [ ] CHANGELOG更新
 - [ ] `main`にマージ
 - [ ] タグ作成
 - [ ] `develop`にタグをマージ
+- [ ] **developのバージョンを次版SNAPSHOTに更新**（例: `0.0.19-SNAPSHOT`）
 - [ ] npm publish（必要に応じて）
 
 ---


### PR DESCRIPTION
## Summary

- DEVELOPMENT_WORKFLOW.mdにSNAPSHOT運用ルールを追記（6.2節）
- 並行開発時の機能名サフィックス規則を定義
- チェックリストにバージョン関連項目を追加

## 変更内容

### バージョン命名規則

| フェーズ | バージョン例 |
|---------|------------|
| リリース済み | `0.0.17` |
| 開発中（develop） | `0.0.18-SNAPSHOT` |
| 開発中（feature） | `0.0.18-SNAPSHOT.cli-npx` |

### semver準拠

```
0.0.17 < 0.0.18-SNAPSHOT < 0.0.18-SNAPSHOT.cli-npx < 0.0.18
```

## Note

- package.jsonのバージョン更新（0.0.18-SNAPSHOT）は本PRには含まず、別途対応
- Related to #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)