### PR TITLE
fix: code-reviewer.mdを元のバージョンに復元

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -23,7 +23,7 @@ You review recently written or modified code to ensure quality, correctness, mai
 
 4. **チェックリストの確認**: `docs/standards/REVIEW_CHECKLIST.md` の各項目を**実際に確認**し、結果を記録する
    - 各項目について ✅（OK）/ ❌（NG）/ N/A（該当なし）を付ける
-   - **特に「ドキュメント」セクションは必ず確認すること**
+   - **特に「ドキュメント」セクションは必ず確認すること**（マスター設計書の更新漏れを防ぐ）
    - 1つでも ❌ がある場合は Request Changes とする
 
 5. **Systematic Review**: Examine the code for:
@@ -44,31 +44,21 @@ Provide your review in this structured format:
 
 ### 📝 チェックリスト確認結果
 
-**重要: 各項目を実際に確認し、結果を記入すること。未確認の項目があってはならない。**
+**重要: 各項目を実際に確認し、結果を記入すること。**
 
-#### 自動チェック
-- [ ] lint PASS → ✅ / ❌ / N/A
-- [ ] format PASS → ✅ / ❌ / N/A
-- [ ] test PASS → ✅ / ❌ / N/A
-- [ ] build PASS → ✅ / ❌ / N/A
+| カテゴリ | 項目 | 結果 |
+|---------|------|------|
+| 自動チェック | test PASS | ✅ / ❌ / N/A |
+| 自動チェック | build PASS | ✅ / ❌ / N/A |
+| コード品質 | コーディング標準準拠 | ✅ / ❌ / N/A |
+| コード品質 | アーキテクチャ準拠 | ✅ / ❌ / N/A |
+| セキュリティ | 機密情報なし | ✅ / ❌ / N/A |
+| ドキュメント | 要件定義書 | ✅ / ❌ / N/A |
+| ドキュメント | 詳細仕様書 | ✅ / ❌ / N/A |
+| **ドキュメント** | **マスター設計書更新** | ✅ / ❌ / N/A |
+| ドキュメント | トレーサビリティ | ✅ / ❌ / N/A |
 
-#### コード品質
-- [ ] コーディング標準に準拠 → ✅ / ❌ / N/A
-- [ ] 命名規則に準拠 → ✅ / ❌ / N/A
-- [ ] アーキテクチャ準拠（依存関係ルール） → ✅ / ❌ / N/A
-- [ ] 不要なコード・コメントなし → ✅ / ❌ / N/A
-
-#### セキュリティ
-- [ ] 入力検証が適切 → ✅ / ❌ / N/A
-- [ ] 機密情報がハードコードされていない → ✅ / ❌ / N/A
-
-#### ドキュメント（該当する場合）
-- [ ] 要件定義書が存在 → ✅ / ❌ / N/A
-- [ ] 詳細仕様書（案件仕様書）が存在 → ✅ / ❌ / N/A
-- [ ] **マスター設計書が更新されている** → ✅ / ❌ / N/A
-- [ ] トレーサビリティが更新されている → ✅ / ❌ / N/A
-
-**判定**: ❌が1つでもあれば → **Request Changes**
+**判定ルール**: ❌ が1つでもあれば → Request Changes
 
 ### ✅ 良い点
 - （コードの良い点をリストアップ）
@@ -92,6 +82,15 @@ Provide your review in this structured format:
 
 ### 📝 総評
 （全体的な評価とコメント）
+
+### 📋 Review Criteria
+<details>
+<summary>このレビューで使用した基準</summary>
+
+- [docs/standards/CODING_STANDARDS.md](../blob/develop/docs/standards/CODING_STANDARDS.md) - コーディング標準
+- [docs/standards/REVIEW_CHECKLIST.md](../blob/develop/docs/standards/REVIEW_CHECKLIST.md) - レビューチェックリスト
+
+</details>
 
 ## Guidelines
 


### PR DESCRIPTION
## Summary

PR #68 のコミット `1f355e4` で誤って含まれた `.claude/agents/code-reviewer.md` の変更を取り消します。

## 問題

`1f355e4` は REQ-CLI-001.md の追加のみを意図していましたが、以下の無関係な変更が含まれていました：

- チェックリスト形式：テーブル → チェックボックス
- "(マスター設計書の更新漏れを防ぐ)" の削除
- "Review Criteria" セクションの削除

## 修正内容

`ba5c633` コミット時点の `code-reviewer.md` に復元。

🤖 Generated with [Claude Code](https://claude.com/claude-code)