### PR TITLE
chore: v0.0.18リリース準備

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,3 +20,11 @@ now-pv.xlsx
 now.xlsm
 prev.xlsm
 要員計画*.xlsx
+
+# Claude Code関連（開発ツール設定）
+.claude/
+CLAUDE.md
+ai_instructions.md
+
+# 開発ドキュメント
+docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づき、
 [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
-## [Unreleased]
+## [0.0.18]
 
 ### 追加
 - **CsvProjectCreator**: CSVファイルからProjectを生成する機能
@@ -29,6 +29,12 @@
 
 ### 変更
 - `package.json`: Jest関連依存とiconv-liteを追加
+
+### 修正
+- **CLIコマンド**: shebang追加でUnix環境での実行を修正
+  - `pbevm-show-project`, `pbevm-diff`, `pbevm-show-pv`
+  - 要件定義: `docs/specs/requirements/REQ-CLI-001.md`
+- **README.md**: インストール手順と`-p`オプションの説明を追加
 
 ## [0.0.17]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "evmtools-node",
-    "version": "0.0.18-SNAPSHOT.review-criteria-links",
+    "version": "0.0.18",
     "description": "このライブラリは、プライムブレインズ社で利用している「進捗管理ツール(Excel)」ファイルを読み込み、 プロジェクトの進捗状況や要員別の作業量を可視化するためのライブラリです。",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- `.npmignore`: Claude関連ファイルとdocs/をnpmパッケージから除外
- `CHANGELOG.md`: v0.0.18セクション追加（CLI shebang修正の記載）
- `package.json`: バージョンを0.0.18に更新

## 変更内容

### 除外対象ファイル
| 対象 | サイズ | 理由 |
|------|--------|------|
| `.claude/` | 60 KB | 開発ツール設定（秘密鍵含む） |
| `CLAUDE.md` | 13 KB | 開発ガイド |
| `ai_instructions.md` | 0 B | 空ファイル |
| `docs/` | 350 KB | 開発ドキュメント |
| **合計削減** | **約420 KB** | パッケージサイズ大幅削減 |

## Test plan
- [ ] `npm pack`でパッケージを作成し、除外ファイルが含まれないことを確認
- [ ] `npm test && npm run build` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)