### PR TITLE
docs: ドキュメント参照を相対パスリンクに変更 (#78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ git push -u origin feature/機能名
 - `main`ブランチからのfeatureブランチ作成
 - developを経由しないマージ
 
-詳細は `docs/workflow/DEVELOPMENT_WORKFLOW.md` を参照。
+詳細は [`docs/workflow/DEVELOPMENT_WORKFLOW.md`](docs/workflow/DEVELOPMENT_WORKFLOW.md) を参照。
 
 ## 注意事項
 
@@ -275,9 +275,9 @@ git push -u origin feature/機能名
 
 | ドキュメント | パス | 内容 |
 |-------------|------|------|
-| 開発ワークフロー | `docs/workflow/DEVELOPMENT_WORKFLOW.md` | 全体フロー、必須セクション |
-| サンプル開発フロー | `docs/workflow/SAMPLE_DEVELOPMENT_FLOW.md` | REQ-TASK-001の実例 |
-| トレーサビリティ例 | `docs/examples/TRACEABILITY_EXAMPLE.md` | AC→TC追跡の具体例 |
+| 開発ワークフロー | [`DEVELOPMENT_WORKFLOW.md`](docs/workflow/DEVELOPMENT_WORKFLOW.md) | 全体フロー、必須セクション |
+| サンプル開発フロー | [`SAMPLE_DEVELOPMENT_FLOW.md`](docs/workflow/SAMPLE_DEVELOPMENT_FLOW.md) | REQ-TASK-001の実例 |
+| トレーサビリティ例 | [`TRACEABILITY_EXAMPLE.md`](docs/examples/TRACEABILITY_EXAMPLE.md) | AC→TC追跡の具体例 |
 
 ### 仕様書の必須セクション
 

--- a/docs/specs/domain/master/VersionInfo.spec.md
+++ b/docs/specs/domain/master/VersionInfo.spec.md
@@ -94,6 +94,6 @@ function getVersionInfo(): VersionInfo;
 
 | ドキュメント | パス |
 |-------------|------|
-| 要件定義 | docs/specs/requirements/REQ-VERSION-001.md |
+| 要件定義 | [`REQ-VERSION-001.md`](../../requirements/REQ-VERSION-001.md) |
 | テスト | src/common/__tests__/VersionInfo.test.ts |
 | 実装 | src/common/VersionInfo.ts |

--- a/docs/specs/requirements/REQ-CLI-001.md
+++ b/docs/specs/requirements/REQ-CLI-001.md
@@ -41,9 +41,9 @@ npm公開済みのCLIコマンド（`pbevm-show-project`, `pbevm-diff`, `pbevm-s
 
 | ファイル | 対応するbinコマンド |
 |---------|-------------------|
-| `src/presentation/cli-pbevm-show-project.ts` | `pbevm-show-project` |
-| `src/presentation/cli-pbevm-diff.ts` | `pbevm-diff` |
-| `src/presentation/cli-pbevm-show-pv.ts` | `pbevm-show-pv` |
+| [`cli-pbevm-show-project.ts`](../../../src/presentation/cli-pbevm-show-project.ts) | `pbevm-show-project` |
+| [`cli-pbevm-diff.ts`](../../../src/presentation/cli-pbevm-diff.ts) | `pbevm-diff` |
+| [`cli-pbevm-show-pv.ts`](../../../src/presentation/cli-pbevm-show-pv.ts) | `pbevm-show-pv` |
 
 ### 2.2 README.md更新
 
@@ -128,9 +128,9 @@ pbevm-show-project --path ./now.xlsm
 | ドキュメント | パス | 説明 |
 |-------------|------|------|
 | GitHub Issue | #67 | CLIコマンドのshebang設定・bin登録の整備 |
-| 詳細仕様書 | `docs/specs/domain/features/CLI.shebang.spec.md` | shebang追加の詳細仕様 |
+| 詳細仕様書 | [`CLI.shebang.spec.md`](../domain/features/CLI.shebang.spec.md) | shebang追加の詳細仕様 |
 | 実装 | `src/presentation/cli-pbevm-*.ts` | CLIファイル |
-| 自動テスト | `src/presentation/__tests__/cli-shebang.test.ts` | CLI shebang検証テスト |
+| 自動テスト | [`cli-shebang.test.ts`](../../../src/presentation/__tests__/cli-shebang.test.ts) | CLI shebang検証テスト |
 | README | `README.md` | 使用方法の説明 |
 
 ---

--- a/docs/specs/requirements/REQ-CLI-002.md
+++ b/docs/specs/requirements/REQ-CLI-002.md
@@ -92,9 +92,9 @@ console.table(displayData);
 
 | 成果物 | パス |
 |--------|------|
-| 案件設計書 | `docs/specs/domain/features/PbevmShowPvUsecase.cli-output-cleanup.spec.md` |
-| テストコード | `src/usecase/__tests__/pbevm-show-pv-usecase.test.ts` |
-| 実装 | `src/usecase/pbevm-show-pv-usecase.ts` |
+| 案件設計書 | [`PbevmShowPvUsecase.cli-output-cleanup.spec.md`](../domain/features/PbevmShowPvUsecase.cli-output-cleanup.spec.md) |
+| テストコード | [`pbevm-show-pv-usecase.test.ts`](../../../src/usecase/__tests__/pbevm-show-pv-usecase.test.ts) |
+| 実装 | [`pbevm-show-pv-usecase.ts`](../../../src/usecase/pbevm-show-pv-usecase.ts) |
 
 ---
 
@@ -104,5 +104,5 @@ console.table(displayData);
 |-------------|------|------|
 | GitHub Issue | #72 | CLI出力から不要なプロパティを除去 |
 | 関連Issue | #73 | pbevm-diff出力から不要なプロパティを除去 |
-| CLI実装 | `src/presentation/cli-pbevm-show-pv.ts` | pbevm-show-pv実装 |
-| CLI実装 | `src/presentation/cli-pbevm-show-project.ts` | pbevm-show-project実装 |
+| CLI実装 | [`cli-pbevm-show-pv.ts`](../../../src/presentation/cli-pbevm-show-pv.ts) | pbevm-show-pv実装 |
+| CLI実装 | [`cli-pbevm-show-project.ts`](../../../src/presentation/cli-pbevm-show-project.ts) | pbevm-show-project実装 |

--- a/docs/specs/requirements/REQ-CLI-003.md
+++ b/docs/specs/requirements/REQ-CLI-003.md
@@ -102,11 +102,11 @@ console.table(displayData);
 |-------------|------|------|
 | GitHub Issue | #73 | pbevm-diff出力から不要なプロパティを除去 |
 | 関連Issue | #72 | CLI出力から不要なプロパティを除去 |
-| 詳細仕様書 | `docs/specs/domain/features/CLI.pbevm-diff-output.spec.md` | 変更仕様 |
-| テストコード | `src/usecase/__tests__/pbevm-diff-usecase.test.ts` | 単体テスト（7件） |
-| 実装 | `src/usecase/pbevm-diff-usecase.ts` | formatTaskDiffsForDisplay関数 |
-| CLI実装 | `src/presentation/cli-pbevm-diff.ts` | pbevm-diffエントリーポイント |
-| ドメイン | `src/domain/ProjectService.ts` | TaskDiff型定義 |
+| 詳細仕様書 | [`CLI.pbevm-diff-output.spec.md`](../domain/features/CLI.pbevm-diff-output.spec.md) | 変更仕様 |
+| テストコード | [`pbevm-diff-usecase.test.ts`](../../../src/usecase/__tests__/pbevm-diff-usecase.test.ts) | 単体テスト（7件） |
+| 実装 | [`pbevm-diff-usecase.ts`](../../../src/usecase/pbevm-diff-usecase.ts) | formatTaskDiffsForDisplay関数 |
+| CLI実装 | [`cli-pbevm-diff.ts`](../../../src/presentation/cli-pbevm-diff.ts) | pbevm-diffエントリーポイント |
+| ドメイン | [`ProjectService.ts`](../../../src/domain/ProjectService.ts) | TaskDiff型定義 |
 
 ---
 

--- a/docs/specs/requirements/REQ-CSV-001.md
+++ b/docs/specs/requirements/REQ-CSV-001.md
@@ -160,11 +160,11 @@ class CsvProjectCreator implements ProjectCreator {
 
 | ドキュメント | パス | 説明 |
 |-------------|------|------|
-| 設計書 | `docs/specs/domain/master/CsvProjectCreator.spec.md` | 詳細仕様 |
-| 設計書(YAML) | `docs/specs/domain/master/CsvProjectCreator.spec.yaml` | 機械可読形式 |
-| 単体テスト | `src/infrastructure/__tests__/CsvProjectCreator.test.ts` | 22件 |
-| 統合テスト | `src/infrastructure/__tests__/CsvProjectCreator.integration.test.ts` | 10件 |
-| 実装 | `src/infrastructure/CsvProjectCreator.ts` | 本体実装 |
+| 設計書 | [`CsvProjectCreator.spec.md`](../domain/master/CsvProjectCreator.spec.md) | 詳細仕様 |
+| 設計書(YAML) | [`CsvProjectCreator.spec.yaml`](../domain/master/CsvProjectCreator.spec.yaml) | 機械可読形式 |
+| 単体テスト | [`CsvProjectCreator.test.ts`](../../../src/infrastructure/__tests__/CsvProjectCreator.test.ts) | 22件 |
+| 統合テスト | [`CsvProjectCreator.integration.test.ts`](../../../src/infrastructure/__tests__/CsvProjectCreator.integration.test.ts) | 10件 |
+| 実装 | [`CsvProjectCreator.ts`](../../../src/infrastructure/CsvProjectCreator.ts) | 本体実装 |
 
 ---
 

--- a/docs/specs/requirements/REQ-TASK-001.md
+++ b/docs/specs/requirements/REQ-TASK-001.md
@@ -127,9 +127,9 @@ const validTasks = project.toTaskRows().filter(t => t.validStatus.isValid)
 
 | ドキュメント | パス | 説明 |
 |-------------|------|------|
-| 設計書 | `docs/specs/domain/features/Project.excludedTasks.spec.md` | 詳細仕様 |
-| 実装 | `src/domain/Project.ts` | excludedTasksプロパティ、ExcludedTask型 |
-| テスト | `src/domain/__tests__/Project.excludedTasks.test.ts` | 10件 |
+| 設計書 | [`Project.excludedTasks.spec.md`](../domain/features/Project.excludedTasks.spec.md) | 詳細仕様 |
+| 実装 | [`Project.ts`](../../../src/domain/Project.ts) | excludedTasksプロパティ、ExcludedTask型 |
+| テスト | [`Project.excludedTasks.test.ts`](../../../src/domain/__tests__/Project.excludedTasks.test.ts) | 10件 |
 
 ---
 

--- a/docs/specs/requirements/REQ-VERSION-001.md
+++ b/docs/specs/requirements/REQ-VERSION-001.md
@@ -85,10 +85,10 @@ function getVersionInfo(): VersionInfo;
 
 | ドキュメント | パス | 説明 |
 |-------------|------|------|
-| 設計書 | `docs/specs/domain/master/VersionInfo.spec.md` | 詳細仕様 |
-| 単体テスト | `src/common/__tests__/VersionInfo.test.ts` | 5件 |
-| 実装 | `src/common/VersionInfo.ts` | 本体実装 |
-| 実装 | `src/common/index.ts` | エクスポート追加 |
+| 設計書 | [`VersionInfo.spec.md`](../domain/master/VersionInfo.spec.md) | 詳細仕様 |
+| 単体テスト | [`VersionInfo.test.ts`](../../../src/common/__tests__/VersionInfo.test.ts) | 5件 |
+| 実装 | [`VersionInfo.ts`](../../../src/common/VersionInfo.ts) | 本体実装 |
+| 実装 | [`index.ts`](../../../src/common/index.ts) | エクスポート追加 |
 
 ---
 

--- a/docs/workflow/DEVELOPMENT_WORKFLOW.md
+++ b/docs/workflow/DEVELOPMENT_WORKFLOW.md
@@ -163,6 +163,21 @@ src/infrastructure/              │
 │   └── CsvProjectCreator.integration.test.ts
 ```
 
+> **📝 ドキュメント内のファイル参照について**
+>
+> 要件定義書・設計書でファイルパスを記載する際は、Markdownの相対パスリンクを使用すること。
+>
+> ```markdown
+> <!-- ✅ 良い例：相対パスリンク -->
+> | 設計書 | [`CsvProjectCreator.spec.md`](../domain/master/CsvProjectCreator.spec.md) |
+> | テスト | [`CsvProjectCreator.test.ts`](../../../src/infrastructure/__tests__/CsvProjectCreator.test.ts) |
+>
+> <!-- ❌ 悪い例：リンクなしのパス表記 -->
+> | 設計書 | `docs/specs/domain/master/CsvProjectCreator.spec.md` |
+> ```
+>
+> これにより、GitHub上やVSCodeでクリックによるファイル参照が可能になる。
+
 ##### 2.2.3.1 案件仕様書とマスター設計書
 
 仕様書には2種類ある：
@@ -459,9 +474,9 @@ grep "AC-01" docs/specs/domain/features/Xxx.spec.md
 
 ##### 参考：正しいフォーマットの仕様書
 
-- `docs/specs/domain/master/CsvProjectCreator.spec.md` - セクション10に要件トレーサビリティあり
-- `docs/specs/domain/master/Project.spec.md` - セクション10に要件トレーサビリティあり
-- `docs/specs/domain/features/Project.excludedTasks.spec.md` - セクション7に要件トレーサビリティあり
+- [`CsvProjectCreator.spec.md`](../specs/domain/master/CsvProjectCreator.spec.md) - セクション10に要件トレーサビリティあり
+- [`Project.spec.md`](../specs/domain/master/Project.spec.md) - セクション10に要件トレーサビリティあり
+- [`Project.excludedTasks.spec.md`](../specs/domain/features/Project.excludedTasks.spec.md) - セクション7に要件トレーサビリティあり
 
 ##### 案件設計書とマスター設計書の同期
 


### PR DESCRIPTION
## Summary
- ドキュメント内の実在ファイルへの参照を相対パスリンクに変更
- ドキュメント間のナビゲーションを容易にする

## Related Issue
Closes #78

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `docs/workflow/DEVELOPMENT_WORKFLOW.md` | 仕様書への参照を相対パスリンク化 |
| `docs/specs/requirements/REQ-CLI-001.md` | 詳細仕様書への参照を相対パスリンク化 |
| `docs/specs/requirements/REQ-CLI-002.md` | 案件設計書への参照を相対パスリンク化 |
| `docs/specs/requirements/REQ-CLI-003.md` | 詳細仕様書への参照を相対パスリンク化 |
| `docs/specs/requirements/REQ-CSV-001.md` | 設計書への参照を相対パスリンク化 |
| `docs/specs/requirements/REQ-TASK-001.md` | 設計書への参照を相対パスリンク化 |
| `docs/specs/requirements/REQ-VERSION-001.md` | 設計書への参照を相対パスリンク化 |
| `docs/specs/domain/master/VersionInfo.spec.md` | 要件定義書への参照を相対パスリンク化 |

## Test plan
- [x] リンク先ファイルの存在確認済み
- [x] 相対パスの正確性確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)