### PR TITLE
docs: SDD スキルの範囲外を明記

### DIFF
--- a/.claude/skills/sdd/SKILL.md
+++ b/.claude/skills/sdd/SKILL.md
@@ -149,6 +149,20 @@ docs/specs/
 - 仕様書作成後のコードレビューは `code-reviewer` エージェントを使用
 - `/sdd verify` 実行時、実装とスペックの整合性を確認
 
+## SDD の範囲外（手動で実施）
+
+> **重要**: 以下の作業は SDD スキルの範囲外です。ユーザーが明示的に依頼する必要があります。
+
+| 作業 | コマンド例 |
+|------|-----------|
+| PR 作成 | `gh pr create --base develop` |
+| PR レビュー | `/review-pr-bot {PR番号}` |
+| PR マージ | `gh pr merge` |
+| main へのリリース | release ブランチ → PR → マージ → タグ |
+| worktree クリーンアップ | `git worktree remove ...` |
+
+**SDD の終点**: `/sdd impl` でコミット・プッシュまで完了した時点。
+
 ## 参照ドキュメント
 
 SDDワークフロー実行時は以下を参照:


### PR DESCRIPTION
## Summary
- SDD スキルのドキュメントに「SDD の範囲外」セクションを追加
- PR 作成・レビュー・マージ・リリース・worktree クリーンアップが SDD の範囲外であることを明記
- SDD の終点が `/sdd impl` でのコミット・プッシュ完了時点であることを明記

## Test plan
- [ ] SKILL.md の内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)