### PR TITLE
chore: class.pu を npm パッケージから除外

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -28,3 +28,6 @@ ai_instructions.md
 
 # 開発ドキュメント
 docs/
+
+# その他
+class.pu


### PR DESCRIPTION
## Summary
- `.npmignore` に `class.pu` を追加
- npm パッケージに PlantUML 図を含めないようにする

🤖 Generated with [Claude Code](https://claude.com/claude-code)