### PR TITLE
chore: bump version to 0.0.26-SNAPSHOT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "evmtools-node",
-    "version": "0.0.25",
+    "version": "0.0.26-SNAPSHOT",
     "description": "このライブラリは、プライムブレインズ社で利用している「進捗管理ツール(Excel)」ファイルを読み込み、 プロジェクトの進捗状況や要員別の作業量を可視化するためのライブラリです。",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- リリース v0.0.25 後の開発版バージョンに更新
- DEVELOPMENT_WORKFLOW.md 4.2 に従い、develop ブランチのバージョンを SNAPSHOT 形式に変更

## Test plan
- [x] バージョン形式が semver 準拠であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)