### PR TITLE
chore: bump version to 0.0.29-SNAPSHOT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "evmtools-node",
-    "version": "0.0.28-SNAPSHOT",
+    "version": "0.0.29-SNAPSHOT",
     "description": "このライブラリは、プライムブレインズ社で利用している「進捗管理ツール(Excel)」ファイルを読み込み、 プロジェクトの進捗状況や要員別の作業量を可視化するためのライブラリです。",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
## 次期開発バージョンの設定

0.0.28 リリース後、次期開発バージョンを設定します。

- package.json: 0.0.28-SNAPSHOT → 0.0.29-SNAPSHOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)