### PR TITLE
ci,build: lint を CI に統合し設定の不具合を修正（#1059 PR B）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
+      # lockfile 未コミットのため setup-node の cache は使わない（cache はロックファイル必須）
       - run: npm install --no-audit --no-fund
       - run: npm run lint
       - run: npm run format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+# CI（masatomix/task#1055 Phase 1 / #1059、evmtools-node#124 を実現）。
+# lint / format / typecheck / test / build を実行する。lockfile は未コミットのため
+# npm install を使用する。ESLint 9 / typescript-eslint v8 の要求に合わせ Node は 20.19+ / 22.13+。
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm install --no-audit --no-fund
+      - run: npm run lint
+      - run: npm run format
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,22 @@
 import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import prettier from 'eslint-config-prettier'
+import globals from 'globals'
 
 export default [
   {
-    ignores: ['dist/**', 'eslint.config.mjs'],
+    // 本体ソース(src)以外は lint 対象外。docs/examples・samples は実行例の
+    // スクリプトで tsconfig.json にも含まれない。
+    ignores: ['dist/**', 'coverage/**', 'node_modules/**', 'docs/**', 'samples/**', 'eslint.config.mjs'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
+    // 型対応 lint は tsconfig.json の対象（src 配下の本体 .ts）に限定する。
+    // テスト/spec は tsconfig.json から exclude されているため project に含めない。
     files: ['**/*.ts'],
+    ignores: ['**/*.test.ts', '**/*.spec.ts'],
     languageOptions: {
       parserOptions: {
         project: ['./tsconfig.json'],
@@ -18,7 +24,44 @@ export default [
       },
     },
     rules: {
-      // 任意: プロジェクトに合わせて調整可能
+      // 型情報必須の strict 系は段階導入（Phase 1 では CI を通すため warn、
+      // 型定義クリーンアップ（Phase 3A）で error へ引き上げる）。型情報がある
+      // src の本体 .ts にのみ適用する。
+      '@typescript-eslint/no-unsafe-assignment': 'warn',
+      '@typescript-eslint/no-unsafe-member-access': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/no-unsafe-call': 'warn',
+      '@typescript-eslint/no-unsafe-return': 'warn',
+      '@typescript-eslint/restrict-template-expressions': 'warn',
+      '@typescript-eslint/require-await': 'warn',
+    },
+  },
+  {
+    // JS 設定ファイルは CommonJS / Node 実行。型情報必須ルールを無効化し node globals を与える。
+    files: ['**/*.{js,cjs,mjs}'],
+    ...tseslint.configs.disableTypeChecked,
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+  {
+    // テスト/spec は tsconfig.json 対象外のため型情報必須ルールを無効化する。
+    files: ['**/*.test.ts', '**/*.spec.ts'],
+    ...tseslint.configs.disableTypeChecked,
+  },
+  {
+    // 構文ベースの cleanup 系（型情報不要）は全ファイルで warn にし、CI を通しつつ
+    // 可視化する（dead code 除去・any 解消は Phase 3A）。
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
     },
   },
   prettier,

--- a/package.json
+++ b/package.json
@@ -1,113 +1,116 @@
 {
-    "name": "evmtools-node",
-    "version": "0.0.29-SNAPSHOT",
-    "description": "このライブラリは、プライムブレインズ社で利用している「進捗管理ツール(Excel)」ファイルを読み込み、 プロジェクトの進捗状況や要員別の作業量を可視化するためのライブラリです。",
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "exports": {
-        "./common": {
-            "types": "./dist/common/index.d.ts",
-            "import": "./dist/common/index.js"
-        },
-        "./domain": {
-            "types": "./dist/domain/index.d.ts",
-            "import": "./dist/domain/index.js"
-        },
-        "./infrastructure": {
-            "types": "./dist/infrastructure/index.d.ts",
-            "import": "./dist/infrastructure/index.js"
-        },
-        "./presentation": {
-            "types": "./dist/presentation/index.d.ts",
-            "import": "./dist/presentation/index.js"
-        },
-        "./usecase": {
-            "types": "./dist/usecase/index.d.ts",
-            "import": "./dist/usecase/index.js"
-        },
-        "./logger": {
-            "types": "./dist/logger.d.ts",
-            "import": "./dist/logger.js"
-        },
-        "./project": {
-            "types": "./dist/project/index.d.ts",
-            "import": "./dist/project/index.js"
-        },
-        "./resource": {
-            "types": "./dist/resource/index.d.ts",
-            "import": "./dist/resource/index.js"
-        }
+  "name": "evmtools-node",
+  "version": "0.0.29-SNAPSHOT",
+  "description": "このライブラリは、プライムブレインズ社で利用している「進捗管理ツール(Excel)」ファイルを読み込み、 プロジェクトの進捗状況や要員別の作業量を可視化するためのライブラリです。",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "./common": {
+      "types": "./dist/common/index.d.ts",
+      "import": "./dist/common/index.js"
     },
-    "bin": {
-        "pbevm-show-project": "./dist/presentation/cli-pbevm-show-project.js",
-        "pbevm-diff": "./dist/presentation/cli-pbevm-diff.js",
-        "pbevm-show-pv": "./dist/presentation/cli-pbevm-show-pv.js",
-        "pbevm-show-resourceplan": "./dist/resource/presentation/cli-pbevm-show-resourceplan.js",
-        "pbevm-tree": "./dist/presentation/cli-pbevm-tree.js"
+    "./domain": {
+      "types": "./dist/domain/index.d.ts",
+      "import": "./dist/domain/index.js"
     },
-    "scripts": {
-        "typecheck": "tsc --noEmit",
-        "pretest": "npm run typecheck",
-        "test": "jest",
-        "test:coverage": "jest --coverage",
-        "lint": "eslint . --ext .ts",
-        "lint:fix": "eslint . --ext .ts --fix",
-        "format": "prettier --check 'src/**/*.ts'",
-        "format:fix": "prettier --write 'src/**/*.ts'",
-        "clean:modules": "rimraf node_modules pnpm-lock.yaml",
-        "clean": "rimraf dist",
-        "tsc": "tsc",
-        "copy:assets": "cpx \"src/**/*.hbs\" dist",
-        "build": "npm-run-all clean tsc copy:assets",
-        "pack": "npm pack",
-        "prepublishOnly": "npm run build",
-        "pbevm-show-project": "ts-node ./src/presentation/cli-pbevm-show-project --path now.xlsm",
-        "pbevm-diff": "ts-node ./src/presentation/cli-pbevm-diff --path now.xlsm --prevPath prev.xlsm",
-        "pbevm-show-pv": "ts-node ./src/presentation/cli-pbevm-show-pv --path now.xlsm",
-        "cli-test": "ts-node ./src/presentation/cli-test --excelPath now.xlsm",
-        "pbevm-summary": "ts-node ./src/presentation/cli-pbevm-summary --path now.xlsm",
-        "pbevm-show-resourceplan": "ts-node ./src/resource/presentation/cli-pbevm-show-resourceplan",
-        "pbevm-tree": "ts-node ./src/presentation/cli-pbevm-tree --path now.xlsm"
+    "./infrastructure": {
+      "types": "./dist/infrastructure/index.d.ts",
+      "import": "./dist/infrastructure/index.js"
     },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/masatomix/evmtools-node.git"
+    "./presentation": {
+      "types": "./dist/presentation/index.d.ts",
+      "import": "./dist/presentation/index.js"
     },
-    "keywords": [
-        "typescript",
-        "javascript"
-    ],
-    "author": "Masatomi KINO <masatomix@ki-no.org> (http://qiita.com/masatomix)",
-    "license": "ISC",
-    "dependencies": {
-        "@tidyjs/tidy": "^2.5.2",
-        "config": "^4.0.0",
-        "excel-csv-read-write": "^0.2.6",
-        "handlebars": "^4.7.8",
-        "iconv-lite": "^0.7.1",
-        "pino": "^9.7.0",
-        "ts-node": "^10.9.2",
-        "yargs": "^17.7.2"
+    "./usecase": {
+      "types": "./dist/usecase/index.d.ts",
+      "import": "./dist/usecase/index.js"
     },
-    "devDependencies": {
-        "@eslint/js": "^9.28.0",
-        "@types/config": "^3.3.5",
-        "@types/iconv-lite": "^0.0.1",
-        "@types/jest": "^30.0.0",
-        "@types/node": "^22.15.21",
-        "@types/xlsx-populate": "github:JanLoebel/types-xlsx-populate",
-        "@types/yargs": "^17.0.33",
-        "cpx": "^1.5.0",
-        "eslint": "^9.28.0",
-        "eslint-config-prettier": "^10.1.5",
-        "eslint-plugin-import": "^2.31.0",
-        "jest": "^30.2.0",
-        "npm-run-all": "^4.1.5",
-        "pino-pretty": "^13.0.0",
-        "prettier": "^3.5.3",
-        "rimraf": "^6.0.1",
-        "ts-jest": "^29.4.6",
-        "typescript": "^5.8.3",
-        "typescript-eslint": "^8.33.1"
+    "./logger": {
+      "types": "./dist/logger.d.ts",
+      "import": "./dist/logger.js"
+    },
+    "./project": {
+      "types": "./dist/project/index.d.ts",
+      "import": "./dist/project/index.js"
+    },
+    "./resource": {
+      "types": "./dist/resource/index.d.ts",
+      "import": "./dist/resource/index.js"
     }
+  },
+  "bin": {
+    "pbevm-show-project": "./dist/presentation/cli-pbevm-show-project.js",
+    "pbevm-diff": "./dist/presentation/cli-pbevm-diff.js",
+    "pbevm-show-pv": "./dist/presentation/cli-pbevm-show-pv.js",
+    "pbevm-show-resourceplan": "./dist/resource/presentation/cli-pbevm-show-resourceplan.js",
+    "pbevm-tree": "./dist/presentation/cli-pbevm-tree.js"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "pretest": "npm run typecheck",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --check 'src/**/*.ts'",
+    "format:fix": "prettier --write 'src/**/*.ts'",
+    "clean:modules": "rimraf node_modules pnpm-lock.yaml",
+    "clean": "rimraf dist",
+    "tsc": "tsc",
+    "copy:assets": "cpx \"src/**/*.hbs\" dist",
+    "build": "npm-run-all clean tsc copy:assets",
+    "pack": "npm pack",
+    "prepublishOnly": "npm run build",
+    "pbevm-show-project": "ts-node ./src/presentation/cli-pbevm-show-project --path now.xlsm",
+    "pbevm-diff": "ts-node ./src/presentation/cli-pbevm-diff --path now.xlsm --prevPath prev.xlsm",
+    "pbevm-show-pv": "ts-node ./src/presentation/cli-pbevm-show-pv --path now.xlsm",
+    "cli-test": "ts-node ./src/presentation/cli-test --excelPath now.xlsm",
+    "pbevm-summary": "ts-node ./src/presentation/cli-pbevm-summary --path now.xlsm",
+    "pbevm-show-resourceplan": "ts-node ./src/resource/presentation/cli-pbevm-show-resourceplan",
+    "pbevm-tree": "ts-node ./src/presentation/cli-pbevm-tree --path now.xlsm"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/masatomix/evmtools-node.git"
+  },
+  "keywords": [
+    "typescript",
+    "javascript"
+  ],
+  "author": "Masatomi KINO <masatomix@ki-no.org> (http://qiita.com/masatomix)",
+  "license": "ISC",
+  "dependencies": {
+    "@tidyjs/tidy": "^2.5.2",
+    "config": "^4.0.0",
+    "excel-csv-read-write": "^0.2.6",
+    "handlebars": "^4.7.8",
+    "iconv-lite": "^0.7.1",
+    "pino": "^9.7.0",
+    "ts-node": "^10.9.2",
+    "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.28.0",
+    "@types/config": "^3.3.5",
+    "@types/iconv-lite": "^0.0.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^22.15.21",
+    "@types/xlsx-populate": "github:JanLoebel/types-xlsx-populate",
+    "@types/yargs": "^17.0.33",
+    "cpx": "^1.5.0",
+    "eslint": "^9.28.0",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-import": "^2.31.0",
+    "jest": "^30.2.0",
+    "npm-run-all": "^4.1.5",
+    "pino-pretty": "^13.0.0",
+    "prettier": "^3.5.3",
+    "rimraf": "^6.0.1",
+    "ts-jest": "^29.4.6",
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.33.1"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.13.0"
+  }
 }

--- a/src/domain/Project.ts
+++ b/src/domain/Project.ts
@@ -546,7 +546,7 @@ export class Project {
             // console.table(result)
 
             for (const row of result) {
-                const name = (row.assignee ?? '(未割当)') as string
+                const name = row.assignee ?? '(未割当)'
                 longFormat.push({
                     assignee: name,
                     baseDate: label,
@@ -949,9 +949,8 @@ export interface TaskFilterOptions {
  * 統計情報取得オプション
  * TaskFilterOptions を継承（フィルタ条件を含む）
  */
-export interface StatisticsOptions extends TaskFilterOptions {
-    // 将来の拡張用（例: includeDelayed, groupBy など）
-}
+// 将来の拡張用（例: includeDelayed, groupBy など）。現状はフィルタ条件のみ。
+export type StatisticsOptions = TaskFilterOptions
 
 /**
  * 計算から除外されたタスクの情報

--- a/src/presentation/cli-pbevm-tree.ts
+++ b/src/presentation/cli-pbevm-tree.ts
@@ -66,4 +66,4 @@ const createArgs = () => {
     return argv
 }
 
-main()
+void main()

--- a/src/presentation/project-test2.ts
+++ b/src/presentation/project-test2.ts
@@ -96,7 +96,7 @@ const createArgs = () => {
     return argv
 }
 
-main()
+void main()
 
 function printTable(datas: ProjectProgress[]) {
     const dispDatas = datas.map((data) => {

--- a/src/resource/usecase/pbevm-show-resourceplan-usecase.ts
+++ b/src/resource/usecase/pbevm-show-resourceplan-usecase.ts
@@ -27,7 +27,7 @@ export class PbevmShowResourcePlanUsecase {
         // const creator = new ResourcePlansCreatorImpl(this._path)
         const unitResults = await this._creator.createResourcePlans()
         const outputDir = this._outputDir
-        fs.existsSync(outputDir) || fs.mkdirSync(outputDir)
+        if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir)
 
         const workbook = await createWorkbook()
         console.log('素データ')


### PR DESCRIPTION
## 概要

masatomix/task#1059 の PR B（PR A #168 マージ後の develop ベース）。**evmtools-node#124 を実現**し、lint/format/typecheck/test/build を CI で回す。

Closes #124

## 背景: lint が壊れていた

`npm run lint` は実行自体が失敗していました（既存の eslint.config.mjs の不具合）:
- `recommendedTypeChecked`（型情報必須ルール）が `jest.config.js` 等の JS や、tsconfig.json 対象外のテスト/spec・docs/samples にも適用され "rule requires type information" でエラー（#1057 と同型）
- `lint` スクリプトの `--ext`（ESLint 9 で廃止）も非互換

## 変更内容

**lint 設定の修正**
- 型対応 lint を **src 本体 .ts に限定**（tsconfig.json の対象）。テスト/spec・JS は `disableTypeChecked`（JS には node globals 付与）、docs/samples は lint 対象外
- `lint` スクリプト `eslint . --ext .ts` → `eslint .`
- 型安全 strict 系（no-unsafe-* 等）・cleanup 系（no-explicit-any / no-unused-vars）は**段階導入のため warn**（CI を通しつつ可視化。error 化と dead code 除去は **Phase 3A**）

**correctness 系の lint エラーは実修正**（warn 化せず直した）
- no-floating-promises（`cli-pbevm-tree` / `project-test2` の `main()`）→ `void`
- no-unused-expressions（`fs.existsSync() || fs.mkdirSync()`）→ `if` 文
- no-unnecessary-type-assertion（不要な `as string` 1箇所）→ 除去（※同種で**必要な**箇所は温存）
- no-empty-object-type（空 interface `StatisticsOptions`）→ type 別名化

**CI / engines**
- `.github/workflows/ci.yml`: Node **20/22 matrix** で lint→format→typecheck→test→build（lockfile 未コミットのため `npm install`）
- `engines.node` を ESLint 9 / typescript-eslint v8 要求に合わせ `^20.19.0 || >=22.13.0` に明示

## 検証（ローカル Node 22.15.1）

- `npm run lint`: **0 error / 39 warn**（warn は Phase 3A で解消予定の型債務・dead code）
- `npm run format`: clean
- `npm run typecheck`: OK
- `npm test`: **17 suites / 262 passed, 2 skipped**
- `npm run build`: OK

## 備考

- 39 warnings の内訳は主に既知の any/型安全（Phase 3A の型定義クリーンアップ対象）と未使用 import/var（Phase 3A 3A-7 の dead code 除去対象）。本 PR ではあえて error 化せず、CI を緑にしつつ可視化する方針
- コミットメッセージ中、シェルのバッククォート展開により "--ext" の語が1箇所欠落していますが内容は本文のとおりです

🤖 Generated with [Claude Code](https://claude.com/claude-code)