### PR TITLE
chore: release 0.0.34（docs のみ — 具体例 07/08）

### DIFF
--- a/.kiro/steering/roadmap.md
+++ b/.kiro/steering/roadmap.md
@@ -2,7 +2,11 @@
 
 ## Overview
 
-evmtools-node（工数ベース EVM 分析ライブラリ、v0.0.28）の総合改修プロジェクト。オープン Issue 14件の棚卸し、利用側（masatomix/task の evmtools スキル、evmtools-webui）からの要請、EVM 理論（PMBOK / Earned Schedule）とのギャップ分析、既存バグの洗い出しの結果を、リリース単位の 6 spec に分解した。
+evmtools-node（工数ベース EVM 分析ライブラリ、v0.0.28）の総合改修プロジェクト。
+
+> **利用側の現在地（2026-07-06 更新）**: evmtools スキルは **PrimeBrains/generative-ai** の `.claude/skills/evmtools` に移管済み（masatomix/task 側はディスコン）。ライブラリ→スキルへの統合要請は PrimeBrains/generative-ai#344 参照（check-daily-pv 置換・SPI(t)・evMethod）。
+
+オープン Issue 14件の棚卸し、利用側（evmtools スキル、evmtools-webui）からの要請、EVM 理論（PMBOK / Earned Schedule）とのギャップ分析、既存バグの洗い出しの結果を、リリース単位の 6 spec に分解した。
 
 方針は「バグ修正 → コア強化」の順の段階リリース（v0.0.29〜v0.0.34）。計算ロジックは evmtools-node に集約し、WebUI・CLI・スキルで数値を一致させる（task スキル側の独自実装 3 本をライブラリに取り込む）。コアスキル強化の本丸は Earned Schedule（既存データのみで古典 SPI の終盤 1.0 収束欠点を解消）。
 

--- a/.npmignore
+++ b/.npmignore
@@ -31,3 +31,12 @@ docs/
 
 # その他
 class.pu
+# 仕様駆動開発（cc-sdd）の spec・steering（開発内部文書）
+.kiro/
+
+# 開発設定ファイル
+.vscode/
+.prettierrc
+eslint.config.mjs
+jest.config.js
+samples/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づき、
 [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
+## [0.0.34]
+
+### ドキュメント
+- **具体例ドキュメントを追加**（docs/examples/）: [07-earned-schedule.md](docs/examples/07-earned-schedule.md)（終盤の隠れた失速検出・工程別フィルタ）、[08-ev-method.md](docs/examples/08-ev-method.md)（3方式の EV/SPI 比較・50/50 の罠・保守的予測）。出力例はすべて検証スクリプト（scripts/07,08）の実測値
+- 利用側スキルの移管先（PrimeBrains/generative-ai）を steering に記録
+
 ## [0.0.33]
 
 ### 追加

--- a/docs/examples/07-earned-schedule.md
+++ b/docs/examples/07-earned-schedule.md
@@ -1,0 +1,104 @@
+# Earned Schedule（SPI(t) で時間ベースの遅延を見る）
+
+`Project.calculateEarnedSchedule()`（0.0.31〜）の使い方を説明します。
+
+## なぜ必要か — 古典 SPI は終盤で「必ず」1.0 に近づく
+
+SPI = EV/PV は「量」の比較のため、プロジェクトが完了に近づくと EV も PV も BAC に収束し、**どんなに遅延していても SPI は 1.0 付近に見えます**（実運用データで確認済みの既知問題。詳細: [EVM-KNOWLEDGE.md 知見ⓑ](../EVM-KNOWLEDGE.md)）。
+
+Earned Schedule（Lipke / PMI）は「**現在の出来高に、計画ならいつ到達していたはずか**」を求めて時間で測ることで、これを解消します。
+
+| 指標 | 式 | 意味 |
+|------|-----|------|
+| ES | 累積PV曲線上で EV に到達する時点（稼働日・線形補間） | 出来高の時間換算 |
+| AT | 開始日〜基準日の稼働日数 | 実際の経過時間 |
+| **SPI(t)** | ES / AT | 時間ベースの効率。**終盤でも 1.0 に収束しない** |
+| SV(t) | ES − AT | 「何稼働日遅れているか」を直接表す |
+| IEAC(t) | PD / SPI(t) | この効率が続いた場合の総所要稼働日数 |
+
+## Example 1: 終盤の隠れた失速を検出する
+
+計画10稼働日のプロジェクト。全タスクが「99%」のまま完了せず、基準日は計画終了の1週間後という状況です。
+
+```typescript
+import { ExcelProjectCreator } from 'evmtools-node/infrastructure'
+
+const creator = new ExcelProjectCreator('./now.xlsm')
+const project = await creator.createProject()
+
+const stats = project.getStatistics()
+console.log(`古典SPI = ${stats.spi?.toFixed(2)}`)
+
+const es = project.calculateEarnedSchedule()
+if (es) {
+    console.log(`ES      = ${es.es.toFixed(1)} 稼働日`)
+    console.log(`AT      = ${es.at} 稼働日`)
+    console.log(`SPI(t)  = ${es.spiT?.toFixed(2)}`)
+    console.log(`SV(t)   = ${es.svT.toFixed(1)} 稼働日`)
+    console.log(`IEAC(t) = ${es.iEacT?.toFixed(1)} 稼働日`)
+    console.log(`予測完了日 = ${es.esForecastDate?.toLocaleDateString('ja-JP')}`)
+}
+```
+
+**出力例**（実測。検証スクリプト [scripts/07-earned-schedule.ts](scripts/07-earned-schedule.ts) より）:
+
+```
+古典SPI = 0.99  ← 1.0 目前。「ほぼ順調」に見える
+ES      = 9.9 稼働日（出来高を時間に換算）
+AT      = 15 稼働日（実際の経過時間）
+SPI(t)  = 0.66  ← 時間ベースでは重度の遅延
+SV(t)   = -5.1 稼働日（何稼働日遅れているか）
+IEAC(t) = 15.2 稼働日（この効率だと総所要日数）
+予測完了日 = 2025/8/22
+```
+
+**同じプロジェクトなのに、古典 SPI は 0.99（順調）、SPI(t) は 0.66（5.1稼働日の遅れ）**。これが「終盤の隠れた失速」で、SPI(t) だけが検出できます。
+
+## Example 2: 中盤では両者はほぼ一致する
+
+```
+古典SPI = 0.75 / SPI(t) = 0.75
+→ 中盤は両者がほぼ一致する。乖離が拡大するのは終盤（Example 1）
+```
+
+つまり **SPI(t) は常に SPI の代わりに使ってよい**指標です（中盤は同じ値、終盤は SPI(t) だけが正しい）。使い分けの指針は [EVM-PRIMER.md「判断レシピ」](../EVM-PRIMER.md) を参照してください。
+
+## Example 3: フィルタで「どの工程が足を引っ張っているか」を見る
+
+`TaskFilterOptions` の `filter`（タスク名部分一致）で部分集合の ES を算出できます。
+
+```typescript
+const all = project.calculateEarnedSchedule()
+const design = project.calculateEarnedSchedule({ filter: '設計' })
+const impl = project.calculateEarnedSchedule({ filter: '実装' })
+```
+
+**出力例**（前半5日=設計、後半5日=実装、6稼働日目時点）:
+
+```
+全体:           ES=3.0 SPI(t)=0.50
+設計工程のみ:   ES=2.5 SPI(t)=0.42 ← 足を引っ張っている
+実装工程のみ:   ES=5.5 SPI(t)=0.92 ← ほぼ計画どおり
+※ AT/PD はプロジェクト全期間で共通（部分集合でも変わらない）
+```
+
+## 注意事項
+
+- 戻り値が `undefined` になる条件: 対象タスクが空、開始日/終了日の欠損、BAC ≤ 0。`spiT` は AT=0（基準日が開始日前）で `undefined`
+- **部分集合の早期完了**: フィルタした部分集合の EV が部分集合の BAC に達すると ES は PD（全期間）にクランプされ、SPI(t) > 1 になり得ます（早期完了の表現）
+- EV 算定方式を変えて計算することもできます: `calculateEarnedSchedule({ evMethod: '0/100' })`（→ [08-ev-method.md](08-ev-method.md)）
+
+## 検証スクリプト
+
+このドキュメントの出力例は [scripts/07-earned-schedule.ts](scripts/07-earned-schedule.ts) で再現できます:
+
+```bash
+npx ts-node docs/examples/scripts/07-earned-schedule.ts
+```
+
+## 関連ドキュメント
+
+- [GLOSSARY.md「Earned Schedule 系指標」](../GLOSSARY.md) — 用語定義
+- [EVM-KNOWLEDGE.md 知見ⓑ](../EVM-KNOWLEDGE.md) — 終盤SPI収束の実運用知見
+- [EVM-MANAGEMENT-GUIDE.md](../EVM-MANAGEMENT-GUIDE.md) — 3点見積レシピ（悲観SPI = min(期間SPI, SPI(t))）
+- [Project.spec.md 5.18](../specs/domain/master/Project.spec.md) — API 詳細仕様

--- a/docs/examples/08-ev-method.md
+++ b/docs/examples/08-ev-method.md
@@ -1,0 +1,95 @@
+# EV 算定方式（evMethod で進捗率の主観バイアスを排する）
+
+`StatisticsOptions.evMethod`（0.0.33〜）の使い方を説明します。
+
+## なぜ必要か — 進捗率は主観値
+
+既定の EV は `進捗率 × 工数` で、進捗率は PM がExcel に手動入力する**主観値**です。「90% です」が何週間も続く（90%症候群）と EV が水増しされ、SPI が実態より良く見えます。
+
+PMI 標準の **fixed formula 方式**は、主観の入り込む余地がない客観的な EV 測定技法です:
+
+| 方式 | EV の式 | 特徴 |
+|------|---------|------|
+| `'progressRate'`（既定） | 進捗率 × 工数 | 従来どおり。**未指定なら全 API の挙動は完全に不変** |
+| `'0/100'` | 完了時のみ工数を計上 | 最も保守的・客観的。仕掛かり中は EV=0 |
+| `'50/50'` | 着手で半分、完了で残り | 中間的。着手判定は **actualStartDate の有無** |
+
+## Example 1: 3方式の EV / SPI 比較
+
+4タスク（完了 / 仕掛40%・着手記録あり / 仕掛40%・着手記録なし / 未着手、各5人日）を中間時点で見た例です。
+
+```typescript
+import { ExcelProjectCreator } from 'evmtools-node/infrastructure'
+import type { EvMethod } from 'evmtools-node/domain'
+
+const creator = new ExcelProjectCreator('./now.xlsm')
+const project = await creator.createProject()
+
+for (const evMethod of ['progressRate', '0/100', '50/50'] as const) {
+    const s = project.getStatistics({ evMethod })
+    console.log(`${evMethod}: EV=${s.totalEv} SPI=${s.spi?.toFixed(3)}`)
+}
+```
+
+**出力例**（実測。検証スクリプト [scripts/08-ev-method.ts](scripts/08-ev-method.ts) より）:
+
+```
+| 方式 | EV | SPI | 意味 |
+|------|-----|------|------|
+| progressRate | 9 | 0.750 | 進捗率按分（既定・従来どおり）|
+| 0/100 | 5 | 0.417 | 完了時のみ計上（最も保守的）|
+| 50/50 | 7.5 | 0.625 | 着手で半分+完了で残り |
+```
+
+**同じプロジェクトでも SPI が 0.750 / 0.417 / 0.625 と変わります**。progressRate との差が大きいほど「進捗率の申告に依存した数字」だったことを意味します。定例で `progressRate` と `0/100` を併記すると、水増しの検出器になります。
+
+## Example 2: 50/50 の罠 — actualStartDate が無いと EV=0
+
+```
+50/50 の EV = 7.5
+内訳: 完了5.0 + 着手記録あり2.5 + 着手記録なし0 + 未着手0
+→ タスク3 は進捗率40%でも actualStartDate 未入力のため EV=0（主観排除のため意図的）
+→ 50/50 を使う場合は実績開始日の入力運用が前提
+```
+
+50/50 の着手判定に進捗率を使わないのは**意図的**です（進捗率を使うと排したはずの主観が再混入するため）。**実績開始日を入力する運用があるプロジェクトでのみ 50/50 を使ってください**。運用が無い場合は `0/100` が安全です。
+
+## Example 3: 保守的な完了予測・Earned Schedule への反映
+
+`evMethod` は統計だけでなく、完了予測と Earned Schedule の EV 入力にも一貫して反映されます。
+
+```typescript
+const forecast = project.calculateCompletionForecast({ evMethod: '0/100' })
+const es = project.calculateEarnedSchedule({ evMethod: '0/100' })
+```
+
+**出力例**:
+
+```
+progressRate: 残作業(ETC')=14.7人日 予測完了=2025/8/18 SPI(t)=0.75
+0/100       : 残作業(ETC')=36.0人日 予測完了=2025/9/4 SPI(t)=0.42
+→ 0/100 は仕掛かり分を EV に数えないため、予測が保守的（遅め）に出る
+→ PV/BAC は方式によらず不変（EV 側だけが変わる）
+```
+
+「最悪ケースの完了予測」として `0/100` の予測日を併記する使い方が実用的です。
+
+## 注意事項
+
+- **PV / BAC / AT / PD は evMethod の影響を受けません**（変わるのは EV とその派生指標のみ）
+- 未指定（または `'progressRate'`）の場合、全 API の戻り値は従来と完全に同一です（回帰なし）
+- 完了判定は許容誤差付き（progressRate ≥ 1.0 − 1e-9）。`0.9999999999` は完了扱いです
+- 反映される API: `getStatistics` / `getStatisticsByName` / `calculateCompletionForecast` / `calculateEarnedSchedule`
+
+## 検証スクリプト
+
+```bash
+npx ts-node docs/examples/scripts/08-ev-method.ts
+```
+
+## 関連ドキュメント
+
+- [GLOSSARY.md「EV 算定方式」](../GLOSSARY.md) — 用語定義と 50/50 の罠
+- [EVM-KNOWLEDGE.md 知見ⓕ](../EVM-KNOWLEDGE.md) — 進捗率の主観バイアス（移動ベースライン下の楽観バイアス）
+- [07-earned-schedule.md](07-earned-schedule.md) — SPI(t) との併用
+- [Project.spec.md 5.19](../specs/domain/master/Project.spec.md) — API 詳細仕様

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -28,6 +28,8 @@ main()
 | 04 | [完了予測](./04-completion-forecast.md) | spiOverride、直近SPI、シナリオ分析、信頼度 |
 | 05 | [スナップショット比較](./05-diff-snapshots.md) | calculateTaskDiffs、担当者別差分、進捗分析 |
 | 06 | [CLIコマンド](./06-cli-commands.md) | pbevm-show-project、pbevm-diff、pbevm-show-pv |
+| 07 | [Earned Schedule](./07-earned-schedule.md) | SPI(t)/SV(t)/IEAC(t)、終盤の隠れた失速検出、工程別フィルタ |
+| 08 | [EV 算定方式](./08-ev-method.md) | evMethod（0/100・50/50）、水増し検出、保守的予測 |
 
 ## モジュール構成
 
@@ -78,6 +80,10 @@ const project = await creator.createProject()
 | > 1.0 | 予定より早い |
 | = 1.0 | 予定通り |
 | < 1.0 | 予定より遅い |
+
+### Q: 終盤に SPI が 1.0 に近いのに遅れている気がする
+
+古典 SPI は完了に近づくと機械的に 1.0 へ収束します（既知の欠点）。[07-earned-schedule.md](./07-earned-schedule.md) の SPI(t) を使ってください。終盤でも失速が数値で見えます。
 
 ### Q: 完了予測の信頼度（confidence）とは？
 

--- a/docs/examples/scripts/07-earned-schedule.ts
+++ b/docs/examples/scripts/07-earned-schedule.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env ts-node
+/**
+ * 07-earned-schedule.md のコード検証スクリプト
+ * spec: phase3-earned-schedule-0.0.32（Earned Schedule）
+ *
+ * 実行方法（リポジトリルートから）:
+ *   npx ts-node docs/examples/scripts/07-earned-schedule.ts
+ */
+
+import { date2Sn } from 'excel-csv-read-write'
+import { Project } from '../../../src/domain/Project'
+import { TaskNode } from '../../../src/domain/TaskNode'
+
+// ============================================
+// ヘルパー: 1日タスクを生成
+// ============================================
+function createTask(id: number, name: string, date: Date, progressRate: number, baseDate: Date): TaskNode {
+    const workload = 1
+    const pv = date <= baseDate ? workload : 0
+    const ev = workload * progressRate
+    const plotMap = new Map<number, boolean>()
+    plotMap.set(date2Sn(date), true)
+
+    return new TaskNode(
+        id, id, 1, name,
+        undefined, // assignee
+        workload,
+        date, date, // startDate, endDate
+        undefined, undefined, // actual dates
+        progressRate,
+        1, // scheduledWorkDays
+        pv, ev,
+        pv > 0 ? ev / pv : 0, // spi
+        undefined, undefined, undefined, undefined, // expectedProgressDate, delayDays, remarks, parentId
+        true, // isLeaf
+        plotMap,
+        []
+    )
+}
+
+// 計画10稼働日: 2025-08-01(金), 08-04〜08(月〜金), 08-11〜14(月〜木)
+const plannedDays = [
+    '2025-08-01', '2025-08-04', '2025-08-05', '2025-08-06', '2025-08-07',
+    '2025-08-08', '2025-08-11', '2025-08-12', '2025-08-13', '2025-08-14',
+].map((d) => new Date(d))
+
+function buildProject(name: string, progressRates: number[], baseDate: Date): Project {
+    const tasks = plannedDays.map((date, i) =>
+        createTask(i + 1, `タスク${i + 1}`, date, progressRates[i], baseDate)
+    )
+    return new Project(tasks, baseDate, [], plannedDays[0], plannedDays[plannedDays.length - 1], name)
+}
+
+// ============================================
+// Example 1: 終盤の隠れた失速 — 古典SPIは 0.99、SPI(t) は 0.66
+// ============================================
+function example1() {
+    console.log('=== Example 1: 終盤の隠れた失速（基準日 = 計画終了の1週間後）===\n')
+
+    // 全タスク 99% のまま完了しない。基準日は計画終了(8/14)の1週間後 8/21
+    const baseDate = new Date('2025-08-21')
+    const project = buildProject('終盤失速', Array(10).fill(0.99), baseDate)
+
+    const stats = project.getStatistics()
+    console.log(`古典SPI = ${stats.spi?.toFixed(2)}  ← 1.0 目前。「ほぼ順調」に見える`)
+
+    const es = project.calculateEarnedSchedule()
+    if (es) {
+        console.log(`ES      = ${es.es.toFixed(1)} 稼働日（出来高を時間に換算）`)
+        console.log(`AT      = ${es.at} 稼働日（実際の経過時間）`)
+        console.log(`SPI(t)  = ${es.spiT?.toFixed(2)}  ← 時間ベースでは重度の遅延`)
+        console.log(`SV(t)   = ${es.svT.toFixed(1)} 稼働日（何稼働日遅れているか）`)
+        console.log(`IEAC(t) = ${es.iEacT?.toFixed(1)} 稼働日（この効率だと総所要日数）`)
+        console.log(`予測完了日 = ${es.esForecastDate?.toLocaleDateString('ja-JP')}`)
+    }
+    console.log('')
+}
+
+// ============================================
+// Example 2: 中盤では古典SPIと SPI(t) はほぼ一致する
+// ============================================
+function example2() {
+    console.log('=== Example 2: 中盤の比較（基準日 = 6稼働日目）===\n')
+
+    // 6稼働日経過時点で 4.5 タスク分完了（少し遅れ）
+    const rates = [1, 1, 1, 1, 0.5, 0, 0, 0, 0, 0]
+    const baseDate = new Date('2025-08-08') // 6稼働日目
+    const project = buildProject('中盤', rates, baseDate)
+
+    const stats = project.getStatistics()
+    const es = project.calculateEarnedSchedule()
+    console.log(`古典SPI = ${stats.spi?.toFixed(2)} / SPI(t) = ${es?.spiT?.toFixed(2)}`)
+    console.log('→ 中盤は両者がほぼ一致する。乖離が拡大するのは終盤（Example 1）')
+    console.log('')
+}
+
+// ============================================
+// Example 3: フィルタで工程別の ES を見る（どこが足を引っ張っているか）
+// ============================================
+function example3() {
+    console.log('=== Example 3: フィルタ併用（工程別の時間効率）===\n')
+
+    // 前半5日=設計工程、後半5日=実装工程。基準日は6稼働日目
+    const baseDate = new Date('2025-08-08')
+    const rates = [1, 1, 0.5, 0, 0, 0.5, 0, 0, 0, 0]
+    const tasks = plannedDays.map((date, i) =>
+        createTask(i + 1, i < 5 ? `設計${i + 1}` : `実装${i + 1}`, date, rates[i], baseDate)
+    )
+    const project = new Project(tasks, baseDate, [], plannedDays[0], plannedDays[9], '工程別')
+
+    const all = project.calculateEarnedSchedule()
+    const design = project.calculateEarnedSchedule({ filter: '設計' })
+    const impl = project.calculateEarnedSchedule({ filter: '実装' })
+    console.log(`全体:           ES=${all?.es.toFixed(1)} SPI(t)=${all?.spiT?.toFixed(2)}`)
+    console.log(`設計工程のみ:   ES=${design?.es.toFixed(1)} SPI(t)=${design?.spiT?.toFixed(2)} ← 足を引っ張っている`)
+    console.log(`実装工程のみ:   ES=${impl?.es.toFixed(1)} SPI(t)=${impl?.spiT?.toFixed(2)} ← ほぼ計画どおり`)
+    console.log('※ AT/PD はプロジェクト全期間で共通（部分集合でも変わらない）')
+    console.log('')
+}
+
+example1()
+example2()
+example3()

--- a/docs/examples/scripts/08-ev-method.ts
+++ b/docs/examples/scripts/08-ev-method.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env ts-node
+/**
+ * 08-ev-method.md のコード検証スクリプト
+ * spec: phase5-evmethod-knowledge-0.0.34（EV 算定方式オプション）
+ *
+ * 実行方法（リポジトリルートから）:
+ *   npx ts-node docs/examples/scripts/08-ev-method.ts
+ */
+
+import { date2Sn } from 'excel-csv-read-write'
+import { Project } from '../../../src/domain/Project'
+import { TaskNode } from '../../../src/domain/TaskNode'
+
+// ============================================
+// ヘルパー: 5稼働日にまたがるタスク（workload 5人日）
+// ============================================
+const days = ['2025-08-01', '2025-08-04', '2025-08-05', '2025-08-06', '2025-08-07'].map(
+    (d) => new Date(d)
+)
+const baseDate = new Date('2025-08-05') // 3稼働日目（中間）
+
+function createTask(
+    id: number,
+    name: string,
+    progressRate: number,
+    actualStartDate: Date | undefined
+): TaskNode {
+    const workload = 5
+    const plotMap = new Map<number, boolean>()
+    for (const d of days) plotMap.set(date2Sn(d), true)
+    const plannedDays = days.filter((d) => d <= baseDate).length
+    const pv = (workload / days.length) * plannedDays // 基準日までの計画値 = 3
+    const ev = workload * progressRate
+
+    return new TaskNode(
+        id, id, 1, name,
+        undefined, // assignee
+        workload,
+        days[0], days[days.length - 1],
+        actualStartDate, undefined, // actualStartDate, actualEndDate
+        progressRate,
+        days.length, // scheduledWorkDays
+        pv, ev,
+        pv > 0 ? ev / pv : 0,
+        undefined, undefined, undefined, undefined,
+        true, // isLeaf
+        plotMap,
+        []
+    )
+}
+
+const started = days[0]
+const tasks = [
+    createTask(1, '設計（完了）', 1.0, started),
+    createTask(2, '実装（40%・着手記録あり）', 0.4, started),
+    createTask(3, '試験（40%・着手記録なし）', 0.4, undefined), // ← 50/50 の罠の実演
+    createTask(4, 'リリース（未着手）', 0, undefined),
+]
+const project = new Project(tasks, baseDate, [], days[0], days[days.length - 1], 'evMethod例')
+
+// ============================================
+// Example 1: 3方式の EV / SPI 比較
+// ============================================
+console.log('=== Example 1: 3方式の EV / SPI 比較 ===\n')
+console.log('| 方式 | EV | SPI | 意味 |')
+console.log('|------|-----|------|------|')
+for (const evMethod of ['progressRate', '0/100', '50/50'] as const) {
+    const s = project.getStatistics({ evMethod })
+    console.log(
+        `| ${evMethod} | ${s.totalEv} | ${s.spi?.toFixed(3)} | ` +
+            (evMethod === 'progressRate'
+                ? '進捗率按分（既定・従来どおり）|'
+                : evMethod === '0/100'
+                  ? '完了時のみ計上（最も保守的）|'
+                  : '着手で半分+完了で残り |')
+    )
+}
+console.log('')
+
+// ============================================
+// Example 2: 50/50 の罠 — actualStartDate が無いと EV=0
+// ============================================
+console.log('=== Example 2: 50/50 の着手判定は actualStartDate ===\n')
+const s5050 = project.getStatistics({ evMethod: '50/50' })
+console.log(`50/50 の EV = ${s5050.totalEv}`)
+console.log('内訳: 完了5.0 + 着手記録あり2.5 + 着手記録なし0 + 未着手0')
+console.log('→ タスク3 は進捗率40%でも actualStartDate 未入力のため EV=0（主観排除のため意図的）')
+console.log('→ 50/50 を使う場合は実績開始日の入力運用が前提')
+console.log('')
+
+// ============================================
+// Example 3: 保守的な完了予測（0/100）と ES への反映
+// ============================================
+console.log('=== Example 3: 完了予測・Earned Schedule への反映 ===\n')
+for (const evMethod of ['progressRate', '0/100'] as const) {
+    const f = project.calculateCompletionForecast({ evMethod })
+    const es = project.calculateEarnedSchedule({ evMethod })
+    console.log(
+        `${evMethod.padEnd(12)}: 残作業(ETC')=${f?.etcPrime?.toFixed(1)}人日 ` +
+            `予測完了=${f?.forecastDate?.toLocaleDateString('ja-JP')} SPI(t)=${es?.spiT?.toFixed(2)}`
+    )
+}
+console.log('→ 0/100 は仕掛かり分を EV に数えないため、予測が保守的（遅め）に出る')
+console.log('→ PV/BAC は方式によらず不変（EV 側だけが変わる）')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmtools-node",
-  "version": "0.0.33",
+  "version": "0.0.34-SNAPSHOT",
   "description": "このライブラリは、プライムブレインズ社で利用している「進捗管理ツール(Excel)」ファイルを読み込み、 プロジェクトの進捗状況や要員別の作業量を可視化するためのライブラリです。",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmtools-node",
-  "version": "0.0.34-SNAPSHOT",
+  "version": "0.0.34",
   "description": "このライブラリは、プライムブレインズ社で利用している「進捗管理ツール(Excel)」ファイルを読み込み、 プロジェクトの進捗状況や要員別の作業量を可視化するためのライブラリです。",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## リリース 0.0.34

develop の docs 変更を main へリリース（Git Flow: release/0.0.34）。**コード変更なし・docs のみ**（`git diff main develop` に src/ 変更なしを確認済み）。

### 内容
- 具体例ドキュメント 07（Earned Schedule）/ 08（EV 算定方式）— 出力例は全て実測値
- スキル移管先の steering 記録

テスト409件 PASS、build 成功。中身は develop 経由のマージ済み PR #197/#198。

### マージ後
- [ ] タグ v0.0.34 / npm publish
- [ ] main → develop 還流 + 0.0.35-SNAPSHOT バンプ

🤖 Generated with [Claude Code](https://claude.com/claude-code)