### PR TITLE
chore: excel-csv-read-write ^0.2.7（#50修正版）へ更新 + テストを reject 挙動に

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@tidyjs/tidy": "^2.5.2",
     "config": "^4.0.0",
-    "excel-csv-read-write": "^0.2.6",
+    "excel-csv-read-write": "^0.2.7",
     "handlebars": "^4.7.8",
     "iconv-lite": "^0.7.1",
     "pino": "^9.7.0",

--- a/src/infrastructure/__tests__/ExcelProjectCreator.integration.test.ts
+++ b/src/infrastructure/__tests__/ExcelProjectCreator.integration.test.ts
@@ -35,7 +35,6 @@
 
 import * as path from 'path'
 import * as fs from 'fs'
-import { spawnSync } from 'child_process'
 import { date2Sn } from 'excel-csv-read-write'
 import { ExcelProjectCreator } from '../ExcelProjectCreator'
 import { ExcelBufferProjectCreator } from '../ExcelBufferProjectCreator'
@@ -351,35 +350,12 @@ describe('異常系（現状の実挙動を固定する）', () => {
         await expect(creator.createProject()).rejects.toThrow(/central directory/)
     })
 
-    it(
-        '存在しないファイルは Promise が settle せずプロセスが uncaughtException で落ちる' +
-            '（excelStream2json がストリームの error を処理しないため）',
-        () => {
-            // 現状の実挙動: fs.createReadStream の 'error' イベントにリスナーが無いため、
-            // createProject() の Promise は resolve も reject もされず、
-            // プロセス自体が ENOENT の uncaughtException で異常終了する。
-            // Jest ワーカーを巻き込まないよう子プロセスで観測して挙動を固定する。
-            const missingPath = path.join(FIXTURES_DIR, 'NotExist.xlsx')
-            const creatorPath = path.join(__dirname, '..', 'ExcelProjectCreator.ts')
-            const script = [
-                `require('ts-node').register({ transpileOnly: true })`,
-                `const { ExcelProjectCreator } = require(${JSON.stringify(creatorPath)})`,
-                `new ExcelProjectCreator(${JSON.stringify(missingPath)}).createProject().then(`,
-                `    () => console.log('SETTLED_RESOLVE'),`,
-                `    () => console.log('SETTLED_REJECT')`,
-                `)`,
-            ].join('\n')
-
-            const result = spawnSync(process.execPath, ['-e', script], {
-                cwd: path.join(__dirname, '..', '..', '..'),
-                encoding: 'utf-8',
-                timeout: 60000,
-            })
-
-            expect(result.status).not.toBe(0) // プロセスが異常終了する
-            expect(result.stderr).toContain('ENOENT') // 原因は ENOENT の uncaughtException
-            expect(result.stdout).not.toContain('SETTLED') // Promise は settle しない
-        },
-        90000
-    )
+    it('存在しないファイルは ENOENT で reject される（excel-csv-read-write 0.2.7 のストリームエラー修正）', async () => {
+        // 0.2.6 以前は excelStream2json がストリームの 'error' を処理せず、
+        // Promise が settle しないままプロセスごと uncaughtException で落ちていた
+        // （masatomix/excel-csv-read-write#50。0.2.7 で reject されるよう修正済み）。
+        const missingPath = path.join(FIXTURES_DIR, 'NotExist.xlsx')
+        const creator = new ExcelProjectCreator(missingPath)
+        await expect(creator.createProject()).rejects.toThrow(/ENOENT/)
+    })
 })


### PR DESCRIPTION
## 概要

上流バグ修正（masatomix/excel-csv-read-write#50 → 同 PR #51 → **0.2.7 リリース済み**）への追従。

- 依存 `^0.2.6` → `^0.2.7`（ストリーム 'error' の reject 接続 + axios/csvtojson の CVE 込みバンプ）
- **不存在ファイルのテストを改善**: 「uncaughtException でプロセスごと落ちる」現挙動の子プロセス観測 → 「**ENOENT で reject される**」正しい挙動の直接検証へ。spawnSync が不要になりテストが簡素・高速化
- テスト434件 PASS（両TZ）、lint 0 errors

これで evmtools-node 利用側は、存在しないファイルパスに対して通常の try/catch でエラーハンドリングできるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)